### PR TITLE
#11 - USER & ADMIN, télécharger et visualiser des fichiers PDF

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
         "symfony/flex": "^1.3.1",
         "symfony/form": "5.3.*",
         "symfony/framework-bundle": "5.3.*",
+        "symfony/mime": "5.3.*",
         "symfony/monolog-bundle": "^3.7",
         "symfony/proxy-manager-bridge": "5.3.*",
         "symfony/runtime": "5.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4814e47241c915e4b61d6429ac29c10",
+    "content-hash": "d0c581e1280d73df957625137ffe8979",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -3847,6 +3847,89 @@
             "time": "2021-06-30T08:27:49+00:00"
         },
         {
+            "name": "symfony/mime",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "633e4e8afe9e529e5599d71238849a4218dd497b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/633e4e8afe9e529e5599d71238849a4218dd497b",
+                "reference": "633e4e8afe9e529e5599d71238849a4218dd497b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/mailer": "<4.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/property-access": "^4.4|^5.1",
+                "symfony/property-info": "^4.4|^5.1",
+                "symfony/serializer": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v5.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-21T12:40:44+00:00"
+        },
+        {
             "name": "symfony/monolog-bridge",
             "version": "v5.3.3",
             "source": {
@@ -4319,6 +4402,93 @@
                 }
             ],
             "time": "2021-05-24T10:04:56+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-intl-normalizer": "^1.10",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,3 +25,6 @@ services:
     # please note that last definitions always *replace* previous ones
     App\Controller\LuckyController: ~
 
+    App\Service\FileUploader:
+        arguments:
+            $targetDirectory: '%kernel.project_dir%/public/uploads/brochures'

--- a/src/Controller/FileController.php
+++ b/src/Controller/FileController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Entity\File;
 use App\Form\Type\FileType;
 use App\Repository\FileRepository;
+use App\Service\FileUploader;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\IsGranted;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,13 +63,21 @@ class FileController extends AbstractController
     /**
      * @Route("/create/file", name="file_create")
      */
-    public function createFile(Request $request) : Response
+    public function createFile(Request $request, FileUploader $fileUploader) : Response
     {
         $file = new File();
         $form = $this->createForm(FileType::class, $file);
         $form->handleRequest($request);
 
         if($form->isSubmitted() && $form->isValid()){
+
+            /** @var UploadedFile $brochureFile */
+            $brochureFile = $form->get('brochure')->getData();
+            if ($brochureFile) {
+                $brochureFileName = $fileUploader->upload($brochureFile);
+                $file->setBrochureFilename($brochureFileName);
+            }
+
             $file = $form->getData();
             $user = $this->getUser();
             $file->setUser($user);

--- a/src/Entity/File.php
+++ b/src/Entity/File.php
@@ -43,6 +43,11 @@ class File
      */
     private $user;
 
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $brochureFilename;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -80,6 +85,17 @@ class File
     public function setUser(?User $user): self
     {
         $this->user = $user;
+        return $this;
+    }
+
+    public function getBrochureFilename(): ?string
+    {
+        return $this->brochureFilename;
+    }
+
+    public function setBrochureFilename(?string $brochureFilename): self
+    {
+        $this->brochureFilename = $brochureFilename;
 
         return $this;
     }

--- a/src/Form/Type/FileType.php
+++ b/src/Form/Type/FileType.php
@@ -16,6 +16,29 @@ class FileType extends AbstractType
         $builder
             ->add('titre', TextType::class)
             ->add('description', TextareaType::class)
+            ->add('brochure', \Symfony\Component\Form\Extension\Core\Type\FileType::class, [
+                'label' => 'Votre fichier PDF',
+
+                // unmapped means that this field is not associated to any entity property
+                'mapped' => false,
+
+                // make it optional so you don't have to re-upload the PDF file
+                // every time you edit the Product details
+                'required' => false,
+
+                // unmapped fields can't define their validation using annotations
+                // in the associated entity, so you can use the PHP constraint classes
+                'constraints' => [
+                    new \Symfony\Component\Validator\Constraints\File([
+                        'maxSize' => '5000k',
+                        'mimeTypes' => [
+                            'application/pdf',
+                            'application/x-pdf',
+                        ],
+                        'mimeTypesMessage' => 'Veuillez télécharger un document PDF valide',
+                    ])
+                ],
+            ])
             ->add('valider', SubmitType::class)
         ;
     }

--- a/src/Service/FileUploader.php
+++ b/src/Service/FileUploader.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\HttpFoundation\File\Exception\FileException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\String\Slugger\SluggerInterface;
+
+class FileUploader
+{
+    private $targetDirectory;
+    private $slugger;
+
+    public function __construct($targetDirectory, SluggerInterface $slugger)
+    {
+        $this->targetDirectory = $targetDirectory;
+        $this->slugger = $slugger;
+    }
+
+    public function upload(UploadedFile $file)
+    {
+        $originalFilename = pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME);
+        $safeFilename = $this->slugger->slug($originalFilename);
+        $fileName = $safeFilename.'-'.uniqid().'.'.$file->guessExtension();
+
+        try {
+            $file->move($this->getTargetDirectory(), $fileName);
+        } catch (FileException $e) {
+            // ... handle exception if something happens during file upload
+        }
+
+        return $fileName;
+    }
+
+    public function getTargetDirectory()
+    {
+        return $this->targetDirectory;
+    }
+}

--- a/templates/profile/index.html.twig
+++ b/templates/profile/index.html.twig
@@ -16,8 +16,7 @@
                 <div class="card-body">
                     <div class="card-text d-flex justify-content-center p-2">
                         <img src="https://us.123rf.com/450wm/thesomeday123/thesomeday1231712/thesomeday123171200009/91087331-ic%C3%B4ne-de-profil-d-avatar-par-d%C3%A9faut-pour-le-m%C3%A2le-espace-r%C3%A9serv%C3%A9-photo-gris-vecteur-d-illustrations.jpg"
-                            width="150" height="150"
-                             class="img-fluid rounded-circle" alt="{{ user.username }}" >
+                            width="150" height="150" class="img-fluid rounded-circle" alt="{{ user.username }}" >
                     </div>
                 </div>
                 <div class="p-2">

--- a/templates/show.html.twig
+++ b/templates/show.html.twig
@@ -17,6 +17,11 @@
                     <div class="card-text">
                         {{ myFile.description }}
                     </div>
+                    <div class="card-text">
+                        {% if myFile.brochureFilename %}
+                            <a class="btn btn-primary stretched-link" href="{{ asset('uploads/brochures/' ~ myFile.brochureFilename) }}">Consulter le fichier PDF</a>
+                        {% endif %}
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
L'utilisateur peut télécharger des fichiers PDF et l'administrateur peut les visualiser.

Pour l'utilisation du "mimeTypes", il faut installer : composer require symfony/mime

FileUploader.php : contient la logique de téléchargement.

Closes #11 